### PR TITLE
🐛 Add check uncommited change in merge/sync

### DIFF
--- a/src/controller/merge.go
+++ b/src/controller/merge.go
@@ -25,18 +25,7 @@ func Merge(cmd *cobra.Command, args []string) {
 		exitOnError("Sorry, I can't check if the working directory is clean 😢", err)
 	}
 	if !clean {
-		print.Message("Sorry, but the working directory is not clean 😢", print.Error)
-		res, err := prompt.InputBool("Would you like to save your changes?", true)
-		if err != nil {
-			exitOnError("Sorry, I can't get your answer 😢", err)
-		}
-		if res {
-			// Run save command
-			Save(cmd, args)
-		} else {
-			print.Message("See you later then 😊", print.Info)
-			os.Exit(0)
-		}
+		exitOnError("Uh oh, there are uncommitted changes. Please commit them before merging branches 😢", nil)
 
 	}
 


### PR DESCRIPTION
Because the save cmd requires flag, it can't be called from another command I've removed the call for the merge command
Also, a pull won't work if the working tree isn't clean. I've added a check for the working tree in the sync cmd