### PR TITLE
Fix #16 - Improving performance of profiles loading

### DIFF
--- a/src/profile/profile.go
+++ b/src/profile/profile.go
@@ -203,7 +203,6 @@ func checkGUIOnLinux() bool {
 	// Go'll try to find the executable in the path to run it
 
 	_, err := exec.LookPath("Xorg")
-	fmt.Println(err)
 	return err == nil
 
 }

--- a/src/profile/profile.go
+++ b/src/profile/profile.go
@@ -45,10 +45,16 @@ func exit(err error, message string) {
 
 const serviceName = "gut"
 
+var profileInitialized = false
+
 var ring keyringLinux.Keyring
 
 // Init a config file for the profiles and load it into the config package
-func init() {
+func loadProfileData() {
+	if profileInitialized {
+		return
+	}
+
 	// Get user home directory
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -148,6 +154,8 @@ func init() {
 			Email:    email,
 		})
 	}
+
+	profileInitialized = true
 
 }
 
@@ -254,7 +262,7 @@ func savePassword(id string, password string) {
 				dirPassFolder := path.Join(homeDir, ".password-store")
 				if !checkFolderExists(dirPassFolder) {
 					// We prompt the user to create the password store
-					print.Message("Please set up a password store with pass. To do so, follow this guide: https://gut-cli.dev/error/setup-pass-store", print.None)
+					print.Message(" To save your password, I need pass to be set up. To do so, follow this guide: https://gut-cli.dev/error/setup-pass-store", print.None)
 
 					os.Exit(1)
 				} else {
@@ -272,7 +280,7 @@ func savePassword(id string, password string) {
 
 				// If not, we explain to the user how to install it on his distro
 			} else {
-				exit(errors.New("pass not installed"), "Please install pass with your package manager (https://www.passwordstore.org/#download)")
+				exit(nil, "To save your password, I need pass to be installed. Please install it (https://www.passwordstore.org/#download)")
 			}
 		}
 
@@ -316,6 +324,7 @@ func retrievePassword(id string) (string, error) {
 						print.Message("You can do it with the following command:", print.Info)
 						print.Message("	pass show "+id, print.None)
 						print.Message("To learn more about this, follow this guide: https://gut-cli.dev/error/unlock-pass-store", print.None)
+						os.Exit(1)
 						return "", errors.New("unable to retrieve the password from the keyring")
 					}
 					return string(password.Data), nil
@@ -373,6 +382,9 @@ func deletePassword(id string) error {
 
 // Add a profile to the config file and return the id
 func AddProfile(profile Profile) string {
+	// Load profile data in global variable
+	loadProfileData()
+
 	id, err := nanoid.New()
 	if err != nil {
 		exit(err, "Sorry, I can't generate an id 😓")
@@ -396,10 +408,14 @@ func AddProfile(profile Profile) string {
 
 // Return the profiles array
 func GetProfiles() *[]Profile {
+	// Load profile data in global variable
+	loadProfileData()
 	return &profiles
 }
 
 func RemoveProfile(id string) {
+	// Load profile data in global variable
+	loadProfileData()
 	// Remove profile from the database
 	for i, profile := range profiles {
 		if profile.Id == id {
@@ -417,6 +433,9 @@ func RemoveProfile(id string) {
 }
 
 func CheckIfProfileExists(id string) bool {
+	// Load profile data in global variable
+	loadProfileData()
+
 	for _, profile := range profiles {
 		if profile.Id == id {
 			return true
@@ -455,6 +474,8 @@ func GetProfileIDFromPath(path string) string {
 }
 
 func GetProfileFromPath(path string) (Profile, error) {
+	// Load profile data in global variable
+	loadProfileData()
 	id := GetProfileIDFromPath(path)
 	if id == "" {
 		return Profile{}, errors.New("no profile found in this directory")
@@ -468,6 +489,9 @@ func GetProfileFromPath(path string) (Profile, error) {
 }
 
 func IsAliasAlreadyUsed(alias string) bool {
+	// Load profile data in global variable
+	loadProfileData()
+
 	for _, profile := range profiles {
 		if profile.Alias == alias {
 			return true


### PR DESCRIPTION
This pull request improves performance of gut.
Rather than loading all profiles on each launch, gut will load them only if the command requires it.

For example, `status` doesn't need to load any profiles. Before this pull request, gut would load all profiles even if it's not needed.

## Changes done

To stop this behaviour, the ˋinit` function in the ˋprofileˋ package has been renamed.
This new function is now called on top of every exported functions of the package so that profiles are loaded when needed.
Note : the function won't run twice thanks to a global boolean variable.


## Performance improvement over commands that doesn't require any profiles

This test not scientific at all has been run on Fedora on a DO 512MB ram VPS.

1. Calling ˋgut` before the pull request
```bash
real    0m0.640s
user    0m0.040s
sys     0m0.028s
```

2. Calling ˋgut` after the PR
```bash
real    0m0.100s
user    0m0.033s
sys     0m0.013s
```