### PR TITLE
📈 Update gut version in telemetry automatically

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,9 @@ builds:
     goos:
       - linux
       - windows
+    
+    ldflags:
+      - -X github.com/julien040/gut/src/telemetry.gutVersion={{.Version}}
 
   - binary: gut
     id: gut-darwin
@@ -20,6 +23,9 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
+
+    ldflags:
+      - -X github.com/julien040/gut/src/telemetry.gutVersion={{.Tag}}
 
     #hooks:
     #  post: ['doppler run --command="bash scripts/notarise.sh {{ .Path }}" ']

--- a/src/telemetry/telemetry.go
+++ b/src/telemetry/telemetry.go
@@ -22,7 +22,7 @@ var consentStateKnown = false
 
 const eventServerURL = "https://api-events.gut-cli.dev/v1"
 
-const gutVersion = "0.1.0"
+var gutVersion = "dev"
 
 var wg sync.WaitGroup
 


### PR DESCRIPTION
Thanks to LDflags and goreleaser, the version of gut in telemetry is now in sync with git tags 
There is no need to update it manually.
If gut is built from source, version will default to "dev". See src/telemetry/telemetry.go:25