### PR TITLE
🐛 Fix input issue on Windows with CRLF

### DIFF
--- a/src/prompt/prompt.go
+++ b/src/prompt/prompt.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/julien040/gut/src/print"
@@ -18,7 +19,15 @@ func InputLine(message string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// Remove the delimiter
+	// Remove the delimiter added when submitting with enter
+	// https://github.com/julien040/gut/issues/28
+
+	// Windows ends line with \r\n
+	if runtime.GOOS == "windows" {
+		return strings.TrimSuffix(input, "\r\n"), nil
+	}
+
+	// Other OS end line with \n
 	return strings.TrimSuffix(input, "\n"), nil
 }
 


### PR DESCRIPTION
Inputs read are trimmed by LF `\n` because a new line is like submitting
But Windows use CRLF `\r\n` to end line

Any input on windows ends with CR `\r` before this commit. This caused any input bool not working because they were expecting Y/n, not Y+CR or n+CR

This pull request removes CRLF from windows, and  only LF on macOS/Linux.