### PR TITLE
✨ Add support for SSH URL (Fix #41)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/spf13/cobra v1.6.1
+	github.com/whilp/git-urls v1.0.0
 	github.com/zalando/go-keyring v0.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -7,7 +7,6 @@ package controller
 import (
 	"fmt"
 	"net/mail"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +34,7 @@ func checkURL(str string) bool {
 
 // Return the name of the repo from the URL
 func getRepoNameFromURL(str string) string {
-	parsed, err := url.Parse(str)
+	parsed, err := giturls.Parse(str)
 	if err != nil {
 		return ""
 	} else {
@@ -63,7 +62,7 @@ func makeValidPath(originalPath string, repoName string) string {
 }
 
 func getHost(str string) string {
-	parsed, err := url.Parse(str)
+	parsed, err := giturls.Parse(str)
 	if err != nil {
 		return ""
 	} else {

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	giturls "github.com/whilp/git-urls"
 
 	"github.com/julien040/gut/src/executor"
 	"github.com/julien040/gut/src/print"
@@ -24,12 +25,11 @@ import (
 
 // Return true if the string is a valid URL for git
 func checkURL(str string) bool {
-	parsed, err := url.Parse(str)
+	url, err := giturls.Parse(str)
 	if err != nil {
 		return false
 	} else {
-		// Check if the URL has a scheme and a host
-		return parsed.Scheme != "" && parsed.Host != ""
+		return url.Host != "" && url.Scheme != ""
 	}
 }
 

--- a/src/controller/controller_test.go
+++ b/src/controller/controller_test.go
@@ -115,6 +115,20 @@ func Test_getRepoNameFromURL(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "Valid URL with ssh",
+			args: args{
+				str: "git@github.com:julien040/gut.git",
+			},
+			want: "gut",
+		},
+		{
+			name: "Valid URL with ssh without .git",
+			args: args{
+				str: "git@github.com:julien040/gut",
+			},
+			want: "gut",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -155,7 +169,29 @@ func Test_getHost(t *testing.T) {
 			},
 			want: "gitlab.com:8080",
 		},
+		{
+			name: "Valid URL with ssh",
+			args: args{
+				str: "git@github.com:julien040/gut",
+			},
+			want: "github.com",
+		},
+		{
+			name: "Invalid URL",
+			args: args{
+				str: "",
+			},
+			want: "",
+		},
+		{
+			name: "Valid URL with ssh without path",
+			args: args{
+				str: "git@github.com:julien040",
+			},
+			want: "github.com",
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getHost(tt.args.str); got != tt.want {

--- a/src/controller/controller_test.go
+++ b/src/controller/controller_test.go
@@ -38,6 +38,42 @@ func Test_checkURL(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "Valid URL with ssh",
+			args: args{
+				str: "git@github.com:julien040/gut.git",
+			},
+			want: true,
+		},
+		{
+			name: "Valid URL with ssh without .git",
+			args: args{
+				str: "git@github.com:julien040/gut",
+			},
+			want: true,
+		},
+		{
+			name: "Valid URL with ssh without host",
+			args: args{
+				str: "git@julien040/gut.git",
+			},
+			want: false,
+		},
+		{
+			name: "Valid URL with ssh without scheme",
+			args: args{
+				str: "julien040@git/github.com/julien040/gut.git",
+			},
+			want: false,
+		},
+		{
+			name: "Valid Gitlab URL with ssh",
+			args: args{
+				str: "git@gitlab.com:gitlab-org/gitlab.git",
+			},
+			want: true,
+		},
+
 		// Check URL doesn't support ssh yet
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Due to net/url not being able to parse any SSH URLs, gut was failing to use SSH. 
All input validations were not functioning properly. 

To remedy this, gut now uses "whilp/git-urls" to validate URL input.

I've also added new tests for ssh URLs.