### PR TITLE
✨ Add flag -v to show version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,22 +24,19 @@ package cmd
 import (
 	"os"
 
+	"github.com/julien040/gut/src/controller"
 	"github.com/julien040/gut/src/prompt"
 	"github.com/julien040/gut/src/telemetry"
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "gut",
 	Short: "Simplify your Git journey with Gut",
 	Long: `
 	Gut is a powerful command-line interface (CLI) designed to make Git easier to use.
 	Effortlessly version control your projects with Gut.`,
-
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Run: controller.Root,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -79,5 +76,6 @@ func promptForTelemetry() {
 }
 
 func init() {
+	rootCmd.Flags().BoolP("version", "v", false, "Print the version of Gut and the release date")
 
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2023 Julien CAGNIART
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"github.com/julien040/gut/src/controller"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:     "version",
+	Aliases: []string{"v"},
+	Short:   "Show Gut version",
+	Run:     controller.Version,
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/src/controller/root.go
+++ b/src/controller/root.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"github.com/julien040/gut/src/print"
+	"github.com/julien040/gut/src/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Root(cmd *cobra.Command, args []string) {
+	// Check if the version flag is set
+	version, err := cmd.Flags().GetBool("version")
+	if err != nil {
+		exitOnError("Sorry, I can't retrieve the version flag 😓", err)
+	}
+
+	// Retrieve Gut version and release date
+	gutVersion := telemetry.GetBuildInfo()
+
+	// Case gut is called with -v
+	if version {
+		// When gut is built from source, the version is set to "dev"
+		// We handle this case to avoid printing "gut vdev (1970-01-01)"
+		if gutVersion == "dev" {
+			print.Message("You are running a built from source version of Gut", print.None)
+		} else {
+			// Print Gut version and release date
+			print.Message("gut v%s", print.None, gutVersion)
+		}
+	} else { // Case gut is called without -v
+		// We show the help message
+		cmd.Help()
+	}
+
+}

--- a/src/controller/version.go
+++ b/src/controller/version.go
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"github.com/julien040/gut/src/print"
+	"github.com/julien040/gut/src/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Version(cmd *cobra.Command, args []string) {
+
+	// Retrieve Gut version and release date
+	gutVersion := telemetry.GetBuildInfo()
+
+	// Case gut is called with -v
+	// When gut is built from source, the version is set to "dev"
+	// We handle this case to avoid printing "gut vdev (1970-01-01)"
+	if gutVersion == "dev" {
+		print.Message("You are running a built from source version of Gut", print.None)
+	} else {
+		// Print Gut version and release date
+		print.Message("gut v%s", print.None, gutVersion)
+	}
+
+}

--- a/src/telemetry/telemetry.go
+++ b/src/telemetry/telemetry.go
@@ -32,6 +32,10 @@ func exit(err error, message string) {
 	os.Exit(1)
 }
 
+func GetBuildInfo() string {
+	return gutVersion
+}
+
 func getConsentStateFromFile() {
 	// Get user home directory
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
To retrieve gut version, now you can run `gut -v` or `gut version`

To be able to run `gut -v`, I had to create a controller for the root cmd. 
By default, if no controller is linked to a command, cobra will show the help.

Now, root has a controller : if the -v flag is present, it fetches the version from the telemetry package and prints it. 
If not, it calls cmd.help() to show the help as before

I have also created a version cmd that does the same a `gut -v`.

The version is added to the build by goreleaser thanks to ldflags. 
If gut is built from source, goreleaser is not used so the gut version can't be shown. 
To remediate this, gut -v falls back to "You are running a built from source version of Gut"