### PR TITLE
✨ Add sparse commit

### DIFF
--- a/cmd/save.go
+++ b/cmd/save.go
@@ -29,8 +29,11 @@ import (
 
 // saveCmd represents the save command
 var saveCmd = &cobra.Command{
-	Use:     "save",
-	Short:   "Save (commit) your current work locally",
+	Use:   "save [files...]",
+	Short: "Save (commit) your current work locally",
+	Long: `Save (commit) your current work locally
+To commit only some files, pass them as arguments to the command.
+In case no files are passed as arguments, all files will be committed.`,
 	Aliases: []string{"s", "commit"},
 	Run:     controller.Save,
 }

--- a/src/controller/init.go
+++ b/src/controller/init.go
@@ -26,7 +26,7 @@ func Init(cmd *cobra.Command, args []string) {
 	}
 
 	associateProfileToPath(profile, wd)
-	_, err = executor.Commit(wd, "🎉 Initial commit from Gut")
+	_, err = executor.Commit(wd, "🎉 Initial commit from Gut", nil)
 	if err != nil {
 		exitOnError("Oups, something went wrong while creating the first commit", err)
 	}

--- a/src/controller/pathHelper.go
+++ b/src/controller/pathHelper.go
@@ -87,3 +87,27 @@ func isDirectoryEmpty(path string) (bool, error) {
 	}
 	return false, err
 }
+
+// Merge the path with the current directory if the path is relative
+// and return the absolute path
+// If the path is absolute, return the path
+func mergeLocalPathWithCurrDir(path string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		exitOnError("Sorry, I can't get the current directory 😓", err)
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(wd, path)
+}
+
+// Predicate function to check if the paths exist
+func validatePaths(paths []string) error {
+	for _, path := range paths {
+		if !checkIfPathExist(mergeLocalPathWithCurrDir(path)) {
+			return errors.New("the path " + path + " doesn't exist")
+		}
+	}
+	return nil
+}

--- a/src/executor/git.go
+++ b/src/executor/git.go
@@ -205,6 +205,11 @@ func GitAddAll() error {
 	return runCommand("git", "add", ".")
 }
 
+// Remove all the files from the index
+func GitRemoveAll() error {
+	return runCommand("git", "reset", "HEAD", "--", ".")
+}
+
 // Diff the index with the HEAD and return true if there is no diff
 func GitDiffIndexHead() (bool, error) {
 	// If there is no diff, output will be empty


### PR DESCRIPTION
You can now perform a commit without including all the files by specifying them as args: For example: gut save myfile.go myfile.js

The function starts by verifying if all the paths are valid.
Then, all the logic is passed down to src/executor/commit.go:Commit() 
If len(args)==0, it adds all the files to the staging area. 
Otherwise it empties the staging area and adds only the specified files.