### PR TITLE
v.0.3.0 merge commit 

### DIFF
--- a/cmd/ignore.go
+++ b/cmd/ignore.go
@@ -49,7 +49,22 @@ var listTemplatesCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 }
 
+var updateIgnoreCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Start ignoring previously committed files",
+	Long: `Start ignoring previously committed files
+Sometimes, you may want to stop tracking files that were previously committed.
+However if you just add them to your .gitignore, they will still be tracked.
+To untrack the files that are already being tracked by Git and listed in your .gitignore, you can run this command.
+
+If you want to add a template to your .gitignore, use the command 'gut ignore'.
+`,
+	Run:     controller.IgnoreUpdate,
+	Aliases: []string{"up", "untrack", "fix"},
+}
+
 func init() {
 	rootCmd.AddCommand(ignoreCmd)
 	ignoreCmd.AddCommand(listTemplatesCmd)
+	ignoreCmd.AddCommand(updateIgnoreCmd)
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -22,26 +22,21 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/julien040/gut/src/controller"
 	"github.com/spf13/cobra"
 )
 
 // undoCmd represents the undo command
-var undoCmd = &cobra.Command{
-	Use:   "undo [file]...",
+var resetCmd = &cobra.Command{
+	Use:   "reset [file]...",
 	Short: "Rollback files specified to the last commit (require git)",
 	Long: `Rollback the repository to the last commit. If you have uncommitted changes, they will be lost.
 If zero arguments are passed, all the files will be rolled back.
 If one or more arguments are passed, only the files passed as arguments will be rolled back.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Starting from v.1.0.0, the undo command is deprecated. Please use the reset command instead.")
-		controller.Undo(cmd, args)
-	},
+	Run: controller.Undo,
 }
 
 func init() {
-	rootCmd.AddCommand(undoCmd)
+	rootCmd.AddCommand(resetCmd)
 
 }

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -29,11 +29,15 @@ import (
 
 // saveCmd represents the save command
 var saveCmd = &cobra.Command{
-	Use:   "save [files...]",
+	Use:   "save [-e=[editor]] [-m=message] [-t=title] [files...]",
 	Short: "Save (commit) your current work locally",
 	Long: `Save (commit) your current work locally
 To commit only some files, pass them as arguments to the command.
-In case no files are passed as arguments, all files will be committed.`,
+In case no files are passed as arguments, all files will be committed.
+
+The -e flag allows you to specify the editor to use for writing the commit message.
+If you want to use the default Git editor, you can also use the -e flag without any argument (e.g., git save -e).
+To specify the editor, use the -e flag followed by the editor command (e.g. gut save -e="mate -w")`,
 	Aliases: []string{"s", "commit"},
 	Run:     controller.Save,
 }
@@ -42,5 +46,13 @@ func init() {
 	rootCmd.AddCommand(saveCmd)
 	saveCmd.Flags().StringP("message", "m", "", "The commit message")
 	saveCmd.Flags().StringP("title", "t", "", "The title of the commit")
+
+	// https://github.com/spf13/pflag#setting-no-option-default-values-for-flags
+	// To set the default value of a flag to an empty string, use the NoOptDefVal field.
+	// -e return config
+	// -e "mate -w" return mate -w
+	// no flag return none
+	saveCmd.Flags().StringP("editor", "e", "none", "The editor to use to write the commit message. Set -e to use the default git editor or specify one with -e=\"editor\"")
+	saveCmd.Flag("editor").NoOptDefVal = "config"
 
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/briandowns/spinner v1.20.0
 	github.com/charmbracelet/lipgloss v0.6.0
-	github.com/fatih/color v1.13.0
+	github.com/fatih/color v1.15.0
 	github.com/go-git/go-git v4.7.0+incompatible
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/matoous/go-nanoid/v2 v2.0.0
@@ -56,8 +56,8 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.9 // indirect
-	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
@@ -125,11 +127,15 @@ github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlW
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/src/controller/clone.go
+++ b/src/controller/clone.go
@@ -70,7 +70,7 @@ func Clone(cmd *cobra.Command, args []string) {
 	}
 
 	/* --------------------------------- Clone repo ------------------------------ */
-	fmt.Printf("\nYour repo is %s and will be cloned in %s", color.GreenString(repo), color.BlueString(path))
+	fmt.Fprintf(color.Output, "\nYour repo is %s and will be cloned in %s", color.GreenString(repo), color.BlueString(path))
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond) // Build a new spinner
 	s.Start()
 	err = executor.Clone(repo, path, shouldConserveGitHistory)

--- a/src/controller/error.go
+++ b/src/controller/error.go
@@ -16,7 +16,7 @@ var (
 		Err:     errors.New("error reading input"),
 	}
 	errorWorkingTreeNotClean = GutError{
-		Message: "I can't continue further because the working tree is not clean",
+		Message: "I can't continue further because the working tree is not clean. Commit your changes with gut save",
 		Code:    2,
 		Err:     errors.New("working tree not clean"),
 	}
@@ -56,17 +56,21 @@ func getLinkForError(GutError GutError) string {
 //
 // This should be used when the error is known and can be resolved by the user
 func exitOnKnownError(typeOfError GutError, err error) {
+
+	// When the error is linked to the user input, we don't print the error message
+	// because it's not useful
+	if typeOfError.Code == 1 {
+		os.Exit(1)
+		return
+	}
 	// Print the error message to stderr
 	fmt.Fprintln(os.Stderr, "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, color.RedString("%s (error: %s)\n"), color.RedString(typeOfError.Message), color.RedString(err.Error()))
-		/* print.Message("%s (error: %s)", print.Error, typeOfError.Message, err.Error()) */
 	} else {
 		fmt.Fprintf(os.Stderr, "%s\n", color.RedString(typeOfError.Message))
-		/* print.Message("%s", print.Error, typeOfError.Message) */
 	}
 	fmt.Fprintf(os.Stderr, "To resolve this issue, please follow the instructions on this page: %s\n", getLinkForError(typeOfError))
-	/* print.Message("To resolve this issue, please follow the instructions on this page: %s", print.Optional, getLinkForError(typeOfError)) */
 
 	os.Exit(1)
 }

--- a/src/controller/ignore.go
+++ b/src/controller/ignore.go
@@ -181,6 +181,10 @@ func Ignore(cmd *cobra.Command, args []string) {
 	}
 	template := selectGitignoreTemplate(templates)
 	gitignoreTemplateContent := splitStringByNewLine(template.contents)
+
+	// Add .gut to the gitignore template
+	gitignoreTemplateContent = append(gitignoreTemplateContent, ".gut")
+
 	// Get the difference between the local .gitignore and the gitignore template
 	diff := Difference(gitignoreContent, gitignoreTemplateContent)
 	// Append the difference to the local .gitignore

--- a/src/controller/ignore.go
+++ b/src/controller/ignore.go
@@ -237,3 +237,30 @@ func IgnoreList(cmd *cobra.Command, args []string) {
 	print.Message("Here's the content of the "+temp.name+" template:", print.Info)
 	fmt.Println(temp.contents)
 }
+
+func IgnoreUpdate(cmd *cobra.Command, args []string) {
+	wd, err := os.Getwd()
+	if err != nil {
+		exitOnError("Sorry, I can't get your current working directory 😓", err)
+	}
+
+	// Check if a repo is initialized & git is installed
+	checkIfGitRepoInitialized(wd)
+	checkIfGitInstalled()
+
+	res, err := prompt.InputBool("Do you want to start untracking the files in the .gitignore that were previously tracked by git?", true)
+	if err != nil {
+		exitOnKnownError(errorReadInput, err)
+	}
+
+	if res {
+		err := executor.GitRmCached()
+		if err != nil {
+			exitOnError("Sorry, I couldn't untrack the files 😓", err)
+		} else {
+			print.Message("I've untracked the files for you 🎉", print.Success)
+		}
+
+	}
+
+}

--- a/src/controller/init.go
+++ b/src/controller/init.go
@@ -2,9 +2,11 @@ package controller
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/julien040/gut/src/executor"
 	"github.com/julien040/gut/src/print"
+	"github.com/julien040/gut/src/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +25,23 @@ func Init(cmd *cobra.Command, args []string) {
 	err = executor.Init(wd)
 	if err != nil {
 		exitOnError("Oups, something went wrong while initializing the repository", err)
+	}
+
+	// Ask for a .gitignore
+	res, err := prompt.InputBool("Do you want to create a .gitignore file?", true)
+	if err != nil {
+		exitOnKnownError(errorReadInput, err)
+	}
+	if res {
+		getGitignoreContentFromPath(wd)
+		templates, err := fetchIgnoreList()
+		if err != nil {
+			exitOnError("Sorry, I couldn't fetch the list of available gitignore templates 😓", err)
+		}
+		template := selectGitignoreTemplate(templates)
+		gitignoreTemplateContent := splitStringByNewLine(template.contents)
+		gitignoreTemplateContent = append(gitignoreTemplateContent, ".gut")
+		appendToGitignore(filepath.Join(wd, ".gitignore"), gitignoreTemplateContent, template.name)
 	}
 
 	associateProfileToPath(profile, wd)

--- a/src/controller/merge.go
+++ b/src/controller/merge.go
@@ -27,7 +27,7 @@ func Merge(cmd *cobra.Command, args []string) {
 		exitOnError("Sorry, I can't check if the working directory is clean 😢", err)
 	}
 	if !clean {
-		exitOnError("Uh oh, there are uncommitted changes. Please commit them before merging branches 😢", nil)
+		exitOnKnownError(errorWorkingTreeNotClean, nil)
 
 	}
 

--- a/src/controller/pathHelper_test.go
+++ b/src/controller/pathHelper_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/fatih/color"
 )
 
 func Test_getAbsPathFromInput(t *testing.T) {
@@ -107,7 +109,7 @@ func Test_checkIfPathExist(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := checkIfPathExist(tt.args.path); got != tt.want {
-				fmt.Printf("Path: %s", tt.args.path)
+				fmt.Fprintf(color.Output, "Path: %s", tt.args.path)
 				t.Errorf("checkIfPathExist() = %v, want %v", got, tt.want)
 			}
 		})

--- a/src/controller/profile.go
+++ b/src/controller/profile.go
@@ -269,11 +269,11 @@ func selectProfile(gitURL string, createPossible bool) profile.Profile {
 func Profiles(cmd *cobra.Command, args []string) {
 	print.Message("Print info about the profiles \n", print.Info)
 	profileSelected := selectProfile("", true)
-	fmt.Printf(color.HiBlackString("Profile selected: %s \n"), color.HiBlueString(profileSelected.Alias))
-	fmt.Printf(color.HiBlackString("Email: %s \n"), color.HiBlueString(profileSelected.Email))
-	fmt.Printf(color.HiBlackString("Username: %s \n"), color.HiBlueString(profileSelected.Username))
-	fmt.Printf(color.HiBlackString("Website: %s \n"), color.HiBlueString(profileSelected.Website))
-	fmt.Printf(color.HiBlackString("Internal ID: %s \n"), color.HiBlueString(profileSelected.Id))
+	fmt.Fprintf(color.Output, color.HiBlackString("Profile selected: %s \n"), color.HiBlueString(profileSelected.Alias))
+	fmt.Fprintf(color.Output, color.HiBlackString("Email: %s \n"), color.HiBlueString(profileSelected.Email))
+	fmt.Fprintf(color.Output, color.HiBlackString("Username: %s \n"), color.HiBlueString(profileSelected.Username))
+	fmt.Fprintf(color.Output, color.HiBlackString("Website: %s \n"), color.HiBlueString(profileSelected.Website))
+	fmt.Fprintf(color.Output, color.HiBlackString("Internal ID: %s \n"), color.HiBlueString(profileSelected.Id))
 
 }
 
@@ -290,9 +290,9 @@ func ProfilesList(cmd *cobra.Command, args []string) {
 		return
 	} else {
 
-		fmt.Println(color.HiBlackString("ID | Alias | Username | Website | Email"))
+		fmt.Fprintln(color.Output, color.HiBlackString("ID | Alias | Username | Website | Email"))
 		for key, val := range *profiles {
-			fmt.Printf(color.HiBlackString("%d. %s | %s | %s | %s | %s \n"), key, val.Id, color.HiBlueString(val.Alias), color.HiBlueString(val.Username), color.HiBlueString(val.Website), color.HiBlueString(val.Email))
+			fmt.Fprintf(color.Output, color.HiBlackString("%d. %s | %s | %s | %s | %s \n"), key, val.Id, color.HiBlueString(val.Alias), color.HiBlueString(val.Username), color.HiBlueString(val.Website), color.HiBlueString(val.Email))
 		}
 	}
 }

--- a/src/controller/revert.go
+++ b/src/controller/revert.go
@@ -92,7 +92,7 @@ func Revert(cmd *cobra.Command, args []string) {
 
 	// Prompt the user to choose a commit
 	commit := chooseCommit(commits)
-	fmt.Printf("I will revert the commit to %s created by %s on %s \n\n", color.HiCyanString(getTitleFromCommit(commit.Message)), color.HiCyanString(commit.Author.Name), commit.Author.When.Format("Mon Jan 2 15:04:05 2006"))
+	fmt.Fprintf(color.Output, "I will revert the commit to %s created by %s on %s \n\n", color.HiCyanString(getTitleFromCommit(commit.Message)), color.HiCyanString(commit.Author.Name), commit.Author.When.Format("Mon Jan 2 15:04:05 2006"))
 
 	err = executor.GitRevert(commit.Hash.String())
 	if err != nil {

--- a/src/controller/squash.go
+++ b/src/controller/squash.go
@@ -87,6 +87,12 @@ func Squash(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}
 
+	// If no commit has been pushed, we set the index to the length of the commits
+	// So the user can squash all his commits
+	if indexLatestCommitPushed == -1 {
+		indexLatestCommitPushed = len(commits)
+	}
+
 	// The object.Commit to squash
 	// Gut will soft reset to this commit
 	// And amend it with a new commit and a new message

--- a/src/controller/status.go
+++ b/src/controller/status.go
@@ -35,7 +35,7 @@ func Status(cmd *cobra.Command, args []string) {
 		if err != nil {
 			exitOnError("Sorry, I can't get the current branch 😢", err)
 		}
-		fmt.Printf("On branch %s\n", color.HiGreenString(branch))
+		fmt.Fprintf(color.Output, "On branch %s\n", color.HiGreenString(branch))
 	}
 
 	spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)

--- a/src/controller/switch.go
+++ b/src/controller/switch.go
@@ -58,7 +58,7 @@ func Switch(cmd *cobra.Command, args []string) {
 			}
 			// If not clean, we return an error
 			if !clean {
-				exitOnError("Sorry, you have uncommitted changes. Save them with \"gut save\" before going to another commit or you will lose them", nil)
+				exitOnKnownError(errorWorkingTreeNotClean, nil)
 			}
 
 			// Switch to the commit

--- a/src/controller/sync.go
+++ b/src/controller/sync.go
@@ -34,7 +34,7 @@ func Sync(cmd *cobra.Command, args []string) {
 		exitOnError("Sorry, I can't check if there are uncommited changes 😢", err)
 	}
 	if !clean {
-		exitOnError("Uh oh, there are uncommited changes. Please commit them before syncing with `gut save`", nil)
+		exitOnKnownError(errorWorkingTreeNotClean, nil)
 	}
 
 	// Get the remote

--- a/src/controller/whereami.go
+++ b/src/controller/whereami.go
@@ -37,10 +37,10 @@ func WhereAmI(cmd *cobra.Command, args []string) {
 		exitOnError("Sorry, I can't check if the HEAD is detached 😢", err)
 	}
 	if detached {
-		fmt.Printf("HEAD is detached (lookout mode) at %s\n", color.HiGreenString(hash))
+		fmt.Fprintf(color.Output, "HEAD is detached (lookout mode) at %s\n", color.HiGreenString(hash))
 		return
 	}
 
-	fmt.Printf("HEAD is at %s on branch %s\n", color.HiGreenString(hash), color.HiGreenString(branch))
+	fmt.Fprintf(color.Output, "HEAD is at %s on branch %s\n", color.HiGreenString(hash), color.HiGreenString(branch))
 
 }

--- a/src/executor/config.go
+++ b/src/executor/config.go
@@ -1,0 +1,49 @@
+package executor
+
+import (
+	"errors"
+
+	"github.com/go-git/go-git/v5/config"
+)
+
+// Get a config flag from the specified scope
+//
+// Return "" if the flag is not found
+func getConfigFlagForGivenScope(scope config.Scope, section string, flag string) (string, error) {
+	conf, err := config.LoadConfig(scope)
+	if err != nil {
+		return "", err
+	}
+
+	if !conf.Raw.HasSection(section) {
+		return "", errors.New("section not found")
+	}
+
+	if !conf.Raw.Section(section).HasOption(flag) {
+		return "", errors.New("flag not found")
+	}
+
+	return conf.Raw.Section(section).Option(flag), nil
+
+}
+
+// Get a config flag from the global and system scope
+// in this order
+// Return "" if the flag is not found
+func getConfigFlag(section string, flag string) (string, error) {
+	res, err := getConfigFlagForGivenScope(config.GlobalScope, section, flag)
+	if err != nil {
+		res, err = getConfigFlagForGivenScope(config.SystemScope, section, flag)
+		if err != nil {
+			return "", err
+		}
+		return res, nil
+	}
+	return res, nil
+
+}
+
+// Get the set editor
+func GetConfigEditor() (string, error) {
+	return getConfigFlag("core", "editor")
+}

--- a/src/executor/editor.go
+++ b/src/executor/editor.go
@@ -1,0 +1,48 @@
+package executor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Get an input from the user using the specified editor.
+// Similar to the git commit command that opens the editor to write the commit message
+//
+// Return the input as a string
+func EditorGetText(editor string, defaultText string, wd string, fileTitle string) (string, error) {
+	path := filepath.Join(wd, fileTitle)
+
+	// Create or reset the file to the default text
+	file, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	file.WriteString(defaultText)
+	file.Close()
+
+	// Open the file with the editor
+	// We have to split the editor string to get the command and the arguments
+	commandName := strings.Split(editor, " ")[0]
+	commandArgs := append(strings.Split(editor, " ")[1:], path)
+	cmd := exec.Command(commandName, commandArgs...)
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	// Read the file
+	commitMessage, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	// Remove the file
+	err = os.Remove(path)
+	if err != nil {
+		return "", err
+	}
+
+	return string(commitMessage), nil
+}

--- a/src/prompt/prompt.go
+++ b/src/prompt/prompt.go
@@ -7,13 +7,14 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/julien040/gut/src/print"
 	"github.com/manifoldco/promptui"
 )
 
 // InputLine prompts the user for an input and returns it
 func InputLine(message string) (string, error) {
-	fmt.Printf("%s ", message)
+	fmt.Fprintf(color.Output, "%s ", message)
 	reader := bufio.NewReader(os.Stdin)
 	input, err := reader.ReadString('\n')
 	if err != nil {


### PR DESCRIPTION
This commit merges all features developped recently for the v0.3.0 release.
It fixes issues #58 and #56 .

## Features
- Gitignore templates now include ".gut" to avoid committing user configuration
- New command "git ignore update" to stop tracking previously committed files
- The init command now prompts for a gitignore template
- Errors generated from a dirty working tree are now more helpful
- `gut save` now allows you specify an external editor (instead of using the built-in editor)

## Bug fixes
- Color printing on the Windows Command Prompt should no longer print ANSI codes
- `gut squash` now works with a local-only repository

## Deprecation

### Renaming the `gut undo` command
As pointed out by an HN commenter, the 'undo' command is not well-named.
Its role is to revert the working tree to the state of the last commit, not to undo the last commit. 
This is a subtle but important difference. Therefore, we should rename the command to something more appropriate. I think 'reset' is a good candidate.